### PR TITLE
Enable strict mode with transform-strict-mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,10 @@
         "power-assert"
       ]
     }
-  }
+  },
+  "plugins": [
+    ["transform-strict-mode", {
+      "strict": true
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.8.0",
+    "babel-plugin-transform-strict-mode": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-jsdoc-to-assert": "^1.0.1",
     "babel-preset-power-assert": "^1.0.0",

--- a/src/ToggleAndPattern.js
+++ b/src/ToggleAndPattern.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 const React = require("react");
 import {matchAnd} from "./utils/match-props";
 export default class ToggleAndPattern extends React.Component {

--- a/src/ToggleOrPattern.js
+++ b/src/ToggleOrPattern.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 const React = require("react");
 import {matchOr} from "./utils/match-props";
 export default class ToggleOrPattern extends React.Component {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import ToggleAndPattern from "./ToggleAndPattern";
 import ToggleOrPattern from "./ToggleOrPattern";
 module.exports = {

--- a/src/utils/match-props.js
+++ b/src/utils/match-props.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 export function matchAnd(keys, parentProps, childProps) {
     const childKeys = Object.keys(childProps);
     // all match


### PR DESCRIPTION
I enable strict mode with  [transform-strict-mode](http://babeljs.io/docs/plugins/transform-strict-mode/) instead of writing it on each file. I think we don't have to add it each file. What do you think ?

Thanks in advance. 😄 
